### PR TITLE
Embed coverage-04.dtd into binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+/DerivedData
 /.build
 /Packages
 /*.xcodeproj

--- a/.swiftpm/xcode/xcshareddata/xcschemes/XcodeCoverageConverter.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/XcodeCoverageConverter.xcscheme
@@ -132,6 +132,48 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Resources"
+               BuildableName = "Resources"
+               BlueprintName = "Resources"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ResourcesBundled"
+               BuildableName = "ResourcesBundled"
+               BlueprintName = "ResourcesBundled"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ResourcesEmbedded"
+               BuildableName = "ResourcesEmbedded"
+               BlueprintName = "ResourcesEmbedded"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,12 @@ uninstall:
 test:
 	@swift test
 
+.PHONY: smoke
+smoke: Xcodecoverageconverter
+	xcodebuild -scheme XcodeCoverageConverter test -derivedDataPath DerivedData -destination "platform=macOS"
+	xcrun xccov view --report --json DerivedData/Logs/Test/*.xcresult > coverage.json
+	leaks -atExit -- "$(BUILDDIR)"/release/xcc generate coverage.json . cobertura-xml
+
 .PHONY: clean
 distclean:
 	@rm -f $(BUILDDIR)/release

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ Xcodecoverageconverter: $(SOURCES)
 	@swift build \
 		-c release \
 		--disable-sandbox \
-		--build-path "$(BUILDDIR)"
+		--scratch-path "$(BUILDDIR)"
 
 .PHONY: install
 install: Xcodecoverageconverter

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -21,15 +21,35 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "XcodeCoverageConverter",
-            dependencies: ["Core"],
+            dependencies: ["Core", "ResourcesEmbedded"],
             path: "Sources/XcodeCoverageConverter"),
         .target(
             name: "Core",
-            dependencies: [.product(name: "ArgumentParser", package: "swift-argument-parser")],
+            dependencies: [
+                .target(name: "Resources"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
+            ],
             path: "Sources/Core"),
+        // Resources
+        .target(name: "Resources",
+                path: "Sources/Resources/Main"),
+        .target(name: "ResourcesBundled",
+                path: "Sources/Resources/Bundled",
+                resources: [.copy("coverage-04.dtd")]),
+        .target(name: "ResourcesEmbedded",
+                path: "Sources/Resources/Embedded",
+                linkerSettings: [.unsafeFlags(
+                    ["-Xlinker", "-sectcreate",
+                     "-Xlinker", "__DATA",
+                     "-Xlinker", "__coverage_dtd",
+                     "-Xlinker", "Sources/Resources/Bundled/coverage-04.dtd"]
+                    // verify if the file is embedded by running
+                    // `otool -X -s __DATA __coverage_dtd <path/to/xcc> | xxd -rma`
+                )]),
+        // Tests
         .testTarget(
             name: "CoreTests",
-            dependencies: ["Core"],
-            path: "Tests/CoreTests"),
+            dependencies: ["Core", "ResourcesBundled"],
+            path: "Tests/CoreTests")
     ]
 )

--- a/Sources/Core/Converters/CoberturaXmlConverter.swift
+++ b/Sources/Core/Converters/CoberturaXmlConverter.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Resources
 
 public extension Xccov.Converters {
     enum CoberturaXml {}
@@ -23,8 +24,7 @@ public extension Xccov.Converters.CoberturaXml {
                         timeStamp: TimeInterval = Date().timeIntervalSince1970,
                         currentDirectoryPath: String = FileManager.default.currentDirectoryPath) -> Result<String, Xccov.Error> {
         guard
-            let dtdUrl = URL(string: "http://cobertura.sourceforge.net/xml/coverage-04.dtd"),
-            let dtd = try? XMLDTD(contentsOf: dtdUrl) else {
+            let dtd = try? XMLDTD(data: Resources.coverageDTD) else {
                 return .failure(.conversionFailed("DTD could not be constructed"))
         }
 

--- a/Sources/Resources/Bundled/Resources.swift
+++ b/Sources/Resources/Bundled/Resources.swift
@@ -1,0 +1,43 @@
+//
+//  Resources.swift
+//  
+//
+//  Created by Ilia Shoshin on 25.5.2023.
+//
+
+import Foundation
+import XCTest
+
+@_cdecl("copyCoverageDTD")
+func copyCoverageDTD(_ size: UnsafeMutablePointer<Int>) -> UnsafeMutablePointer<UInt8>? {
+    size.pointee = BundleResource.coverageDTD.size
+    return BundleResource.coverageDTD.unsafeMutablePointer
+}
+
+class BundleResource {
+    var data: Data
+    var size: Int = 0
+
+    // note: call `deallocate()` on the pointer when the data is no longer needed
+    var unsafeMutablePointer: UnsafeMutablePointer<UInt8>? {
+        let mutablePointer = UnsafeMutablePointer<UInt8>.allocate(capacity: size)
+        data.copyBytes(to: mutablePointer, count: size)
+        return mutablePointer
+    }
+
+    static var coverageDTD: BundleResource = {
+        guard let resource = BundleResource(name: "coverage-04", extension: "dtd") else {
+            fatalError("failed to find coverage-04.dtd")
+        }
+        return resource
+    }()
+
+    init?(name: String, `extension`: String) {
+        guard let url = Bundle.module.url(forResource: name, withExtension: `extension`),
+              let data = try? Data(contentsOf: url) else {
+            return nil
+        }
+        self.data = data
+        self.size = data.count
+    }
+}

--- a/Sources/Resources/Bundled/coverage-04.dtd
+++ b/Sources/Resources/Bundled/coverage-04.dtd
@@ -1,0 +1,61 @@
+<!-- Portions (C) International Organization for Standardization 1986:
+     Permission to copy in any form is granted for use with
+     conforming SGML systems and applications as defined in
+     ISO 8879, provided this notice is included in all copies.
+-->
+
+  <!ELEMENT coverage (sources?,packages)>
+  <!ATTLIST coverage line-rate        CDATA #REQUIRED>
+  <!ATTLIST coverage branch-rate      CDATA #REQUIRED>
+  <!ATTLIST coverage lines-covered    CDATA #REQUIRED>
+  <!ATTLIST coverage lines-valid      CDATA #REQUIRED>
+  <!ATTLIST coverage branches-covered CDATA #REQUIRED>
+  <!ATTLIST coverage branches-valid   CDATA #REQUIRED>
+  <!ATTLIST coverage complexity       CDATA #REQUIRED>
+  <!ATTLIST coverage version          CDATA #REQUIRED>
+  <!ATTLIST coverage timestamp        CDATA #REQUIRED>
+
+  <!ELEMENT sources (source*)>
+
+  <!ELEMENT source (#PCDATA)>
+
+  <!ELEMENT packages (package*)>
+
+  <!ELEMENT package (classes)>
+  <!ATTLIST package name        CDATA #REQUIRED>
+  <!ATTLIST package line-rate   CDATA #REQUIRED>
+  <!ATTLIST package branch-rate CDATA #REQUIRED>
+  <!ATTLIST package complexity  CDATA #REQUIRED>
+
+  <!ELEMENT classes (class*)>
+
+  <!ELEMENT class (methods,lines)>
+  <!ATTLIST class name        CDATA #REQUIRED>
+  <!ATTLIST class filename    CDATA #REQUIRED>
+  <!ATTLIST class line-rate   CDATA #REQUIRED>
+  <!ATTLIST class branch-rate CDATA #REQUIRED>
+  <!ATTLIST class complexity  CDATA #REQUIRED>
+
+  <!ELEMENT methods (method*)>
+
+  <!ELEMENT method (lines)>
+  <!ATTLIST method name        CDATA #REQUIRED>
+  <!ATTLIST method signature   CDATA #REQUIRED>
+  <!ATTLIST method line-rate   CDATA #REQUIRED>
+  <!ATTLIST method branch-rate CDATA #REQUIRED>
+  <!ATTLIST method complexity  CDATA #REQUIRED>
+
+  <!ELEMENT lines (line*)>
+
+  <!ELEMENT line (conditions*)>
+  <!ATTLIST line number CDATA #REQUIRED>
+  <!ATTLIST line hits   CDATA #REQUIRED>
+  <!ATTLIST line branch CDATA "false">
+  <!ATTLIST line condition-coverage CDATA "100%">
+
+  <!ELEMENT conditions (condition*)>
+
+  <!ELEMENT condition EMPTY>
+  <!ATTLIST condition number CDATA #REQUIRED>
+  <!ATTLIST condition type CDATA #REQUIRED>
+  <!ATTLIST condition coverage CDATA #REQUIRED>

--- a/Sources/Resources/Embedded/Resources.c
+++ b/Sources/Resources/Embedded/Resources.c
@@ -1,0 +1,46 @@
+//
+//  Resources.c
+//  
+//
+//  Created by Ilia Shoshin on 25.5.2023.
+//
+
+#include <mach-o/getsect.h>
+#include <mach-o/ldsyms.h>
+#include <stdlib.h>
+#include <string.h>
+
+/**
+ * The function extracts the __coverage_dtd section from the __DATA segment.
+ * 
+ * @param[out] size Data size
+ * @return A copy of the data 
+ *         Note: Call `free()` when the data is no longer required.
+ * 
+ * Resources cannot be embeded into some targets (e.g. test targets).
+ * The `_mh_execute_header` symbol is specific to the main executable file, and it points to the 
+ * Mach-O header of that executable in memory. Test targets, on the other hand, are not built as 
+ * standalone executables, so they don't have their own Mach-O headers and the `_mh_execute_header` 
+ * symbol is undefined.
+ * 
+ * The `Copy Rule` is not necessary here, but has been chosen to make it easier to mock the function in Swift:
+ * 
+ *  ```swift
+ *  @_cdecl("copyCoverageDTD")
+ *  func copyCoverageDTD(_ size: UnsafeMutablePointer<Int>) -> UnsafeMutablePointer<UInt8>? {
+ *       let data = ...
+ *       size.pointee = data.size
+ *       let mutablePointer = UnsafeMutablePointer<UInt8>.allocate(capacity: data.size)
+ *       data.copyBytes(to: mutablePointer, count: data.size)
+ *       return mutablePointer
+ *  }
+ *  ```
+ */
+uint8_t *copyCoverageDTD(size_t *size) {
+    unsigned long dataSize;
+    const uint8_t *data = getsectiondata(&_mh_execute_header, "__DATA", "__coverage_dtd", &dataSize);
+    uint8_t *buffer = (uint8_t *)malloc(dataSize);
+    memcpy(buffer, data, dataSize);
+    *size = dataSize;
+    return buffer;
+}

--- a/Sources/Resources/Main/Resources.swift
+++ b/Sources/Resources/Main/Resources.swift
@@ -1,0 +1,23 @@
+//
+//  Resources.swift
+//  
+//
+//  Created by Ilia Shoshin on 25.5.2023.
+//
+
+import Foundation
+
+// Import the C function
+@_silgen_name("copyCoverageDTD")
+func copyCoverageDTD(_ size: UnsafeMutablePointer<Int>) -> UnsafeMutablePointer<UInt8>?
+
+public class Resources {
+public static var coverageDTD: Data {
+    var size: Int = 0
+    guard let dataPtr = copyCoverageDTD(&size) else {
+        fatalError("coverage.dtd is not available")
+    }
+    return Data(bytesNoCopy: dataPtr, count: size, deallocator: .free)
+}
+
+}


### PR DESCRIPTION
* Embed coverage-04.dtd into binary

   The main purpose of embedding the [coverage-04.dtd](http://cobertura.sourceforge.net/xml/coverage-04.dtd) into `xcc`
is to allow `xcc` to work in certain deployment environments where there may be restrictions on Internet access.

* Fix swift build warning
   
   warning: '--build-path' option is deprecated; use '--scratch-path' instead

* Add smoke test

*The description has been edited to reflect the latest changes.*