### PR TITLE
main: bump version to 0.2.2

### DIFF
--- a/Sources/XcodeCoverageConverter/main.swift
+++ b/Sources/XcodeCoverageConverter/main.swift
@@ -5,7 +5,7 @@ import Foundation
 struct Xcc: ParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "A Swift command-line tool to convert xccov outputs into continuous integration friendly formats",
-        version: "0.2.1",
+        version: "0.2.2",
         subcommands: [Generate.self],
         defaultSubcommand: Generate.self)
 


### PR DESCRIPTION
This release embeds the `coverage-04.dtd` into `xcc` (#11) to enhance functionality in environments with restricted internet access.