### PR TITLE
Fix cobertura coverage statistics when filtering packages or targets

### DIFF
--- a/Sources/Core/Filters/TargetsFilter.swift
+++ b/Sources/Core/Filters/TargetsFilter.swift
@@ -14,10 +14,17 @@ public extension Xccov.Filters.Targets {
         guard !targetsToExclude.isEmpty else { return coverageReport }
 
         let targetsToKeep = coverageReport.targets.filter { !$0.name.contains(elementsOf: targetsToExclude) }
-        let filteredCoverageReport = CoverageReport(executableLines: coverageReport.executableLines,
-                                                    targets: targetsToKeep,
-                                                    lineCoverage: coverageReport.lineCoverage,
-                                                    coveredLines: coverageReport.coveredLines)
+        let adjusted = targetsToKeep.reduce(into: (coveredLines: 0, executableLines: 0)) {
+            $0.coveredLines += $1.coveredLines
+            $0.executableLines += $1.executableLines
+        }
+        let filteredCoverageReport = CoverageReport(
+            executableLines: adjusted.executableLines,
+            targets: targetsToKeep,
+            lineCoverage: Double(adjusted.coveredLines) / Double(adjusted.executableLines),
+            coveredLines: adjusted.coveredLines
+        )
+
         return filteredCoverageReport
     }
 }

--- a/Tests/CoreTests/Filters/PackagesFilterTests.swift
+++ b/Tests/CoreTests/Filters/PackagesFilterTests.swift
@@ -11,20 +11,20 @@ import XCTest
 final class PackagesFilterTests: XCTestCase {
     func testFilter_removes_packages_to_exclude() {
         // Given: an input coverageReport with 4 different packages
-        let file1 = FileCoverageReport(coveredLines: 0, executableLines: 0, functions: [], lineCoverage: 0, name: "1", path: "/common/file1")
-        let file2 = FileCoverageReport(coveredLines: 0, executableLines: 0, functions: [], lineCoverage: 0, name: "2", path: "/client1/file2")
-        let file3 = FileCoverageReport(coveredLines: 0, executableLines: 0, functions: [], lineCoverage: 0, name: "3", path: "/client2/file3")
-        let file4 = FileCoverageReport(coveredLines: 0, executableLines: 0, functions: [], lineCoverage: 0, name: "4", path: "/common/file4")
-        let file5 = FileCoverageReport(coveredLines: 0, executableLines: 0, functions: [], lineCoverage: 0, name: "5", path: "/client3/file5")
-        let file6 = FileCoverageReport(coveredLines: 0, executableLines: 0, functions: [], lineCoverage: 0, name: "6", path: "/client1/file6")
+        let file1 = FileCoverageReport(coveredLines: 10, executableLines: 10, functions: [], lineCoverage: 1, name: "1", path: "/common/file1")
+        let file2 = FileCoverageReport(coveredLines: 0, executableLines: 20, functions: [], lineCoverage: 0, name: "2", path: "/client1/file2")
+        let file3 = FileCoverageReport(coveredLines: 0, executableLines: 30, functions: [], lineCoverage: 1, name: "3", path: "/client2/file3")
+        let file4 = FileCoverageReport(coveredLines: 40, executableLines: 40, functions: [], lineCoverage: 1, name: "4", path: "/common/file4")
+        let file5 = FileCoverageReport(coveredLines: 50, executableLines: 50, functions: [], lineCoverage: 1, name: "5", path: "/client3/file5")
+        let file6 = FileCoverageReport(coveredLines: 0, executableLines: 60, functions: [], lineCoverage: 0, name: "6", path: "/client1/file6")
 
         let target1 = TargetCoverageReport(buildProductPath: "", coveredLines: 0, executableLines: 0, files: [file1, file2, file3], lineCoverage: 0, name: "1")
         let target2 = TargetCoverageReport(buildProductPath: "", coveredLines: 0, executableLines: 0, files: [file4, file5, file6], lineCoverage: 0, name: "2")
         let coverageReport = CoverageReport(executableLines: 0, targets: [target1, target2], lineCoverage: 0, coveredLines: 0)
 
-        let expectedTarget1 = TargetCoverageReport(buildProductPath: "", coveredLines: 0, executableLines: 0, files: [file1], lineCoverage: 0, name: "1")
-        let expectedTarget2 = TargetCoverageReport(buildProductPath: "", coveredLines: 0, executableLines: 0, files: [file4, file5], lineCoverage: 0, name: "2")
-        let expectedReport = CoverageReport(executableLines: 0, targets: [expectedTarget1, expectedTarget2], lineCoverage: 0, coveredLines: 0)
+        let expectedTarget1 = TargetCoverageReport(buildProductPath: "", coveredLines: 10, executableLines: 10, files: [file1], lineCoverage: 1, name: "1")
+        let expectedTarget2 = TargetCoverageReport(buildProductPath: "", coveredLines: 90, executableLines: 90, files: [file4, file5], lineCoverage: 1, name: "2")
+        let expectedReport = CoverageReport(executableLines: 100, targets: [expectedTarget1, expectedTarget2], lineCoverage: 1, coveredLines: 100)
 
         // When: filtering the coverage report by excluding packages client1 and client2
         let receivedReport = Xccov.Filters.Packages.filter(coverageReport: coverageReport, packagesToExclude: ["client1", "client2"])

--- a/Tests/CoreTests/Filters/TargetsFilterTests.swift
+++ b/Tests/CoreTests/Filters/TargetsFilterTests.swift
@@ -11,11 +11,11 @@ import XCTest
 final class TargetsFilterTests: XCTestCase {
     func testFilter_removes_targets_to_exclude() {
         // Given: an input coverageReport with target 1, 2 and 3
-        let target1 = TargetCoverageReport(buildProductPath: "", coveredLines: 0, executableLines: 0, files: [], lineCoverage: 0, name: "1")
-        let target2 = TargetCoverageReport(buildProductPath: "", coveredLines: 0, executableLines: 0, files: [], lineCoverage: 0, name: "2")
-        let target3 = TargetCoverageReport(buildProductPath: "", coveredLines: 0, executableLines: 0, files: [], lineCoverage: 0, name: "3")
-        let coverageReport = CoverageReport(executableLines: 0, targets: [target1, target2, target3], lineCoverage: 0, coveredLines: 0)
-        let expectedReport = CoverageReport(executableLines: 0, targets: [target1], lineCoverage: 0, coveredLines: 0)
+        let target1 = TargetCoverageReport(buildProductPath: "", coveredLines: 10, executableLines: 10, files: [], lineCoverage: 0, name: "1")
+        let target2 = TargetCoverageReport(buildProductPath: "", coveredLines: 0, executableLines: 20, files: [], lineCoverage: 1, name: "2")
+        let target3 = TargetCoverageReport(buildProductPath: "", coveredLines: 0, executableLines: 30, files: [], lineCoverage: 1, name: "3")
+        let coverageReport = CoverageReport(executableLines: 40, targets: [target1, target2, target3], lineCoverage: 0.25, coveredLines: 10)
+        let expectedReport = CoverageReport(executableLines: 10, targets: [target1], lineCoverage: 1, coveredLines: 10)
 
         // When: filtering the coverage report by excluding targets 2 and 3
         let receivedReport = Xccov.Filters.Targets.filter(coverageReport: coverageReport, targetsToExclude: ["2", "3"])


### PR DESCRIPTION
Cobertura files include overall coverage statistics on the root `<coverage>` element of the file.  When packages or targets are excluded via `--exclude-packages`, `--exclude-targets` these overall statistics are no longer valid.  While it is possible to recalculate using the included `<line>` elements within the file it is much easier if xcc could do this automatically.

```xml
<!-- a single file is included with 100% coverage, due to excludes 50% is reported -->
<coverage line-rate="0.5" lines-covered="50" lines-valid="100">
  <sources>
    <source>/Developer/MyProject</source>
  </sources>
  <packages>
    <package name="Developer.MyProject.Sources.Foo" line-rate="1">
      <classes>
        <class name="Developer.MyProject.Sources.Foo.Bar" line-rate="1">
          <lines>
            <line number="7" hits="6"/>
          </lines>
        </class>
     </classes>
  </package>
</coverage>
```

This PR recalculates the coverage statistics after any filters have been applied so the resulting cobertura files correctly reflect the statistics of the included files and targets.